### PR TITLE
fix: inverted values in validation maximum_throughput_units

### DIFF
--- a/variables.eventhub.namespace.tf
+++ b/variables.eventhub.namespace.tf
@@ -32,7 +32,7 @@ variable "maximum_throughput_units" {
   description = "Specifies the maximum number of throughput units when Auto Inflate is Enabled. Valid values range from 1 - 20."
 
   validation {
-    condition     = var.maximum_throughput_units == null ? true : var.maximum_throughput_units < 1 || var.maximum_throughput_units > 20
+    condition     = var.maximum_throughput_units == null ? true : var.maximum_throughput_units >= 1 || var.maximum_throughput_units <= 20
     error_message = "Maximum throughput units must be in the range of 1 to 20"
   }
 }


### PR DESCRIPTION
Inverted values in validation maximum_throughput_units  https://github.com/Azure/terraform-azurerm-avm-res-eventhub-namespace/issues/102#event-17753881241

## Description

<!--
>Thank you for your contribution!
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Closes #456
-->
Change the range from 1 to 20. #102

## Type of Change

<!-- Use the check-boxes [x] on the relevant options. -->

- [ ] Non-module change (e.g., CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update: backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update the documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines/checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
